### PR TITLE
Remote hashtag from close button

### DIFF
--- a/gd-bookmarklet.js
+++ b/gd-bookmarklet.js
@@ -171,7 +171,7 @@
                     +     "<div class=\"framework-specific twb\"><label for=\"gdt-nbcols\">Nb cols</label><input type=\"text\" id=\"gdt-nbcols\" value=\"" + gdNbcols + "\" /></div>"
                     +     "<div><label for=\"gdt-zindex\">z-index</label><input type=\"text\" id=\"gdt-zindex\" value=\"" + gdZindex + "\" /></div>"
                     + "  </div>"
-                    + "  <div class=\"gdt-button\" id=\"gdt-ok\"><a href=\"#\">OK</a></div>"
+                    + "  <div class=\"gdt-button\" id=\"gdt-ok\"><a href=\"javascript:;\">OK</a></div>"
                     + "  <div class=\"gdt-button\"><a href=\"javascript:;\" id=\"gdt-close\">Close</a></div>"
                     + "</div>";
 

--- a/gd-bookmarklet.js
+++ b/gd-bookmarklet.js
@@ -172,7 +172,7 @@
                     +     "<div><label for=\"gdt-zindex\">z-index</label><input type=\"text\" id=\"gdt-zindex\" value=\"" + gdZindex + "\" /></div>"
                     + "  </div>"
                     + "  <div class=\"gdt-button\" id=\"gdt-ok\"><a href=\"#\">OK</a></div>"
-                    + "  <div class=\"gdt-button\"><a href=\"#\" id=\"gdt-close\">Close</a></div>"
+                    + "  <div class=\"gdt-button\"><a href=\"javascript:;\" id=\"gdt-close\">Close</a></div>"
                     + "</div>";
 
       $("head").append("<link rel='stylesheet' type='text/css' href='http://alefeuvre.github.com/foundation-grid-displayer/stylesheets/gd-bookmarklet.min.css'>");


### PR DESCRIPTION
Remove hashtag from buttons. When we click on it on a 1 page web application (using javascript framework such Ember or Backbone), it redirects to the main page instead of staying on the current page.
